### PR TITLE
Add TCP transport option

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,11 @@ interactive-feedback-magic/
 uv sync
 
 # 运行服务器
+# 使用默认 stdio 运行服务器
 python server.py
+
+# 使用 TCP 模式（示例）
+python server.py --transport tcp --port 8000
 
 # 测试 UI
 python feedback_ui.py --prompt "测试消息"

--- a/server.py
+++ b/server.py
@@ -330,4 +330,32 @@ def interactive_feedback(
         return ("",)
 
 if __name__ == "__main__":
-    mcp.run(transport="stdio")
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Run the Interactive Feedback MCP server"
+    )
+    parser.add_argument(
+        "--transport",
+        choices=["stdio", "tcp"],
+        default="stdio",
+        help="Transport type for the MCP server",
+    )
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Host address when using TCP transport",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=65432,
+        help="Port number when using TCP transport",
+    )
+
+    args = parser.parse_args()
+
+    if args.transport == "tcp":
+        mcp.run(transport="tcp", host=args.host, port=args.port)
+    else:
+        mcp.run(transport="stdio")


### PR DESCRIPTION
## Summary
- allow `server.py` to run over TCP using `--transport tcp`
- document the new option in the README

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_b_6846011ed8a0832fb19b06cf28f043a1